### PR TITLE
Arreglar problema con textos largos

### DIFF
--- a/app/src/main/res/layout/fragment_question_option2.xml
+++ b/app/src/main/res/layout/fragment_question_option2.xml
@@ -51,7 +51,7 @@
 
     <TextView
         android:id="@+id/respuestaB3"
-        android:layout_width="wrap_content"
+        android:layout_width="622dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
         android:layout_marginTop="80dp"
@@ -78,7 +78,7 @@
 
     <TextView
         android:id="@+id/respuestaA3"
-        android:layout_width="wrap_content"
+        android:layout_width="622dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
         android:layout_marginTop="88dp"

--- a/app/src/main/res/layout/fragment_question_option3.xml
+++ b/app/src/main/res/layout/fragment_question_option3.xml
@@ -51,7 +51,7 @@
 
     <TextView
         android:id="@+id/respuestaA3"
-        android:layout_width="wrap_content"
+        android:layout_width="622dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="28dp"
         android:layout_marginTop="32dp"
@@ -75,7 +75,7 @@
 
     <TextView
         android:id="@+id/respuestaB3"
-        android:layout_width="wrap_content"
+        android:layout_width="622dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="28dp"
         android:layout_marginTop="88dp"
@@ -99,7 +99,7 @@
 
     <TextView
         android:id="@+id/respuestaC3"
-        android:layout_width="wrap_content"
+        android:layout_width="622dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="28dp"
         android:layout_marginTop="80dp"


### PR DESCRIPTION
Se ha solucionado el problema por el que en las preguntas tipo test, si
el texto era demasiado largo, no se podía ver entero en pantalla.
